### PR TITLE
Update project.json to close over beta packages

### DIFF
--- a/src/xunit.runner.dnx/project.json
+++ b/src/xunit.runner.dnx/project.json
@@ -24,19 +24,19 @@
         },
         "dnxcore50": {
             "dependencies": {
-                "System.Collections.Concurrent": "4.0.10-*",
-                "System.Console": "4.0.0-*",
-                "System.Diagnostics.Tools": "4.0.0-*",
-                "System.IO.FileSystem": "4.0.0-*",
-                "System.Linq": "4.0.0-*",
-                "System.ObjectModel": "4.0.10-*",
-                "System.Reflection": "4.0.10-*",
-                "System.Runtime.Extensions": "4.0.10-*",
-                "System.Security.Cryptography.Hashing": "4.0.0-*",
-                "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-*",
-                "System.Text.RegularExpressions": "4.0.10-*",
-                "System.Threading": "4.0.10-*",
-                "System.Xml.XDocument": "4.0.0-*"
+                "System.Collections.Concurrent": "4.0.10-beta-*",
+                "System.Console": "4.0.0-beta-*",
+                "System.Diagnostics.Tools": "4.0.0-beta-*",
+                "System.IO.FileSystem": "4.0.0-beta-*",
+                "System.Linq": "4.0.0-beta-*",
+                "System.ObjectModel": "4.0.10-beta-*",
+                "System.Reflection": "4.0.10-beta-*",
+                "System.Runtime.Extensions": "4.0.10-beta-*",
+                "System.Security.Cryptography.Hashing": "4.0.0-beta-*",
+                "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-*",
+                "System.Text.RegularExpressions": "4.0.10-beta-*",
+                "System.Threading": "4.0.10-beta-*",
+                "System.Xml.XDocument": "4.0.0-beta-*"
             }
         }
     },


### PR DESCRIPTION
The aspnetrelease myget feed has some old, badly versioned packages that will always get selected over what you actually want if you *don't* include the `beta` name, which we do in our libs which is why this hasn't affected us.