### PR TITLE
Use Console instead of Console.Error for skipped tests

### DIFF
--- a/src/xunit.runner.dnx/Visitors/StandardOutputVisitor.cs
+++ b/src/xunit.runner.dnx/Visitors/StandardOutputVisitor.cs
@@ -65,9 +65,9 @@ namespace Xunit.Runner.Dnx
             {
                 // TODO: Thread-safe way to figure out the default foreground color
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.Error.WriteLine("   {0} [FAIL]", Escape(testFailed.Test.DisplayName));
+                Console.WriteLine("   {0} [FAIL]", Escape(testFailed.Test.DisplayName));
                 Console.ForegroundColor = ConsoleColor.Gray;
-                Console.Error.WriteLine("      {0}", ExceptionUtility.CombineMessages(testFailed).Replace(Environment.NewLine, Environment.NewLine + "      "));
+                Console.WriteLine("      {0}", ExceptionUtility.CombineMessages(testFailed).Replace(Environment.NewLine, Environment.NewLine + "      "));
 
                 WriteStackTrace(ExceptionUtility.CombineStackTraces(testFailed));
             }
@@ -86,9 +86,9 @@ namespace Xunit.Runner.Dnx
             {
                 // TODO: Thread-safe way to figure out the default foreground color
                 Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.Error.WriteLine("   {0} [SKIP]", Escape(testSkipped.Test.DisplayName));
+                Console.WriteLine("   {0} [SKIP]", Escape(testSkipped.Test.DisplayName));
                 Console.ForegroundColor = ConsoleColor.Gray;
-                Console.Error.WriteLine("      {0}", Escape(testSkipped.Reason));
+                Console.WriteLine("      {0}", Escape(testSkipped.Reason));
             }
 
             return base.Visit(testSkipped);


### PR DESCRIPTION
Already fixed on xunit/xunit on https://github.com/xunit/xunit/commit/689f154c868a63877f5574a8e39e6032350a42b2
Fixing https://github.com/xunit/xunit/issues/267 for dnx.unit.