### PR TITLE
React to DNX renames in Beta7

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,6 +3,6 @@
   <packageSources>
     <add key="Public Feed" value="https://nuget.org/api/v2/" />
     <add key="CI Builds (xunit)" value="https://www.myget.org/F/xunit/" />
-    <add key="CI Packages (aspnetrelease)" value="http://www.myget.org/F/aspnetrelease/" />
+    <add key="CI Packages (aspnetvnext)" value="http://www.myget.org/F/aspnetvnext/" />
   </packageSources>
 </configuration>

--- a/global.json
+++ b/global.json
@@ -1,4 +1,4 @@
 {
-    "sdk": { "version": "1.0.0-beta7-12263" },
+    "sdk": { "version": "1.0.0-beta7-12264" },
     "sources": [ "src" ]
 }

--- a/global.json
+++ b/global.json
@@ -1,4 +1,4 @@
 {
-    "sdk": { "version": "1.0.0-beta6-12254" },
+    "sdk": { "version": "1.0.0-beta7-12263" },
     "sources": [ "src" ]
 }

--- a/src/xunit.runner.dnx/Program.cs
+++ b/src/xunit.runner.dnx/Program.cs
@@ -150,7 +150,7 @@ namespace Xunit.Runner.Dnx
             var result = new List<IRunnerReporter>();
 
             foreach (var library in libraryManager.GetReferencingLibraries("xunit.runner.utility"))
-                foreach (var assembly in library.LoadableAssemblies)
+                foreach (var assembly in library.Assemblies)
                 {
                     TypeInfo[] types;
 

--- a/src/xunit.runner.dnx/project.json
+++ b/src/xunit.runner.dnx/project.json
@@ -41,9 +41,9 @@
         }
     },
     "dependencies": {
-        "Microsoft.Framework.Runtime.Abstractions": "1.0.0-beta6-*",
-        "Microsoft.Framework.TestAdapter": "1.0.0-beta6-*",
-        "Microsoft.Framework.TestHost": "1.0.0-beta6-*",
+        "Microsoft.Framework.Runtime.Abstractions": "1.0.0-beta7-*",
+        "Microsoft.Framework.TestAdapter": "1.0.0-beta7-*",
+        "Microsoft.Framework.TestHost": "1.0.0-beta7-*",
         "xunit.runner.utility": "2.1.0-beta4-*",
         "xunit.runner.reporters": "2.1.0-beta4-*"
     }


### PR DESCRIPTION
see aspnet/dnx#2225

DNX had some renames that had a small effect on xunit. Really just one property change :).

The DNX with the new renames is not yet on `aspnetvnext` (we're patching locally to get a successful build first). Once it goes live, this can be merged and everything should build fine. I'll ping back when that happens, but I wanted to start the review early so you have a chance to look at the HUGE change :trollface: 

You can verify this change locally, before we get a full build out, by changing the ASP.NET feed to `http://www.myget.org/F/aspnetvolatile/`.

/cc @DamianEdwards @davidfowl @bradwilson 
