### PR TITLE
Change File.OpenWrite to File.Open with FileMode.Create for XML output

### DIFF
--- a/src/xunit.runner.dnx/Utility/TransformFactory.cs
+++ b/src/xunit.runner.dnx/Utility/TransformFactory.cs
@@ -29,7 +29,7 @@ namespace Xunit.Runner.Dnx
 
         static void Handler_DirectWrite(XElement xml, string outputFileName)
         {
-            using (var stream = File.OpenWrite(outputFileName))
+            using (var stream = File.Open(outputFileName, FileMode.Create))
                 xml.Save(stream);
         }
     }


### PR DESCRIPTION
If the XML output file already exists, File.OpenWrite will open the file without truncating the contents with the file pointer at the beginning of the file. If the contents of the previous test run are longer than the XML output from the current test run, there will be excess XML left at the end of the file. This will likely make the XML invalid and may cause errors for any tools that parse the XML (e.g., Jenkins). 

This change ensures that the file will be created or completely overwritten when writing the new test results.